### PR TITLE
[section_09] CsvMovieReader, JaxbMovieReader를 data package로 이동, Movie…

### DIFF
--- a/src/main/java/moviebuddy/MovieBuddyApplication.java
+++ b/src/main/java/moviebuddy/MovieBuddyApplication.java
@@ -1,6 +1,5 @@
 package moviebuddy;
 
-import moviebuddy.domain.CsvMovieReader;
 import moviebuddy.domain.Movie;
 import moviebuddy.domain.MovieFinder;
 import org.springframework.context.ApplicationContext;

--- a/src/main/java/moviebuddy/MovieBuddyFactory.java
+++ b/src/main/java/moviebuddy/MovieBuddyFactory.java
@@ -1,9 +1,5 @@
 package moviebuddy;
 
-import moviebuddy.domain.CsvMovieReader;
-import moviebuddy.domain.MovieFinder;
-import moviebuddy.domain.MovieReader;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.*;
 
 /**

--- a/src/main/java/moviebuddy/data/CsvMovieReader.java
+++ b/src/main/java/moviebuddy/data/CsvMovieReader.java
@@ -1,8 +1,9 @@
-package moviebuddy.domain;
+package moviebuddy.data;
 
 import moviebuddy.ApplicationException;
+import moviebuddy.domain.Movie;
+import moviebuddy.domain.MovieReader;
 import moviebuddy.util.FileSystemUtils;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;

--- a/src/main/java/moviebuddy/data/JaxbMovieReader.java
+++ b/src/main/java/moviebuddy/data/JaxbMovieReader.java
@@ -1,6 +1,8 @@
-package moviebuddy.domain;
+package moviebuddy.data;
 
 import moviebuddy.ApplicationException;
+import moviebuddy.domain.Movie;
+import moviebuddy.domain.MovieReader;
 import org.springframework.stereotype.Repository;
 
 import javax.xml.bind.JAXBContext;

--- a/src/main/java/moviebuddy/domain/MovieFinder.java
+++ b/src/main/java/moviebuddy/domain/MovieFinder.java
@@ -1,22 +1,11 @@
 package moviebuddy.domain;
 
-import moviebuddy.ApplicationException;
-import moviebuddy.util.FileSystemUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/moviebuddy/domain/MovieReader.java
+++ b/src/main/java/moviebuddy/domain/MovieReader.java
@@ -1,5 +1,7 @@
 package moviebuddy.domain;
 
+import moviebuddy.domain.Movie;
+
 import java.util.List;
 
 public interface MovieReader {

--- a/src/test/java/moviebuddy/data/JaxbMovieReaderTest.java
+++ b/src/test/java/moviebuddy/data/JaxbMovieReaderTest.java
@@ -1,5 +1,7 @@
-package moviebuddy.domain;
+package moviebuddy.data;
 
+import moviebuddy.data.JaxbMovieReader;
+import moviebuddy.domain.Movie;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
…Reader(interface)는 domain package 에 위치

* why: 비즈니스로직인 MovieReader는 내부 도메인레이어에 위치하고, Reader 구현체는 외부레이어로 위차하여 좀 더 소프트웨어를 유연하게 변경